### PR TITLE
Fix issues with the recurring expeses being included or not in the monthly diff

### DIFF
--- a/src/main/app/lib/expenses/state/expense_list.dart
+++ b/src/main/app/lib/expenses/state/expense_list.dart
@@ -4,9 +4,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:spend_spent_spent/expenses/models/day_expense.dart';
 import 'package:spend_spent_spent/globals.dart';
 import 'package:spend_spent_spent/expenses/models/search_parameters.dart';
+import 'package:spend_spent_spent/settings/views/screens/settings.dart';
 import 'package:spend_spent_spent/utils/models/with_error.dart';
 
 part 'expense_list.freezed.dart';
@@ -65,7 +67,12 @@ class ExpenseListCubit extends Cubit<ExpenseListState> {
       _log.fine('selected is now: $compareTo');
     }
 
-    var diff = await service.getDiffWithPreviousPeriod(compareDate);
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    final includeRecurring = prefs.getBool(INCLUDE_RECURRING_IN_DIFF);
+    var diff = await service.getDiffWithPreviousPeriod(
+      compareDate,
+      includeRecurring: includeRecurring ?? true,
+    );
     _log.fine('Comparing data up until $compareDate, diff: $diff');
     emit(state.copyWith(diffWithPreviousPeriod: diff));
   }

--- a/src/main/app/pubspec.yaml
+++ b/src/main/app/pubspec.yaml
@@ -1,5 +1,5 @@
 name: 'spend_spent_spent'
-version: '2.6.1+99'
+version: '2.6.2+100'
 publish_to: none
 environment:
   sdk: '>=3.8.0 <4.0.0'

--- a/src/main/java/com/ftpix/sss/controllers/api/ExpenseController.java
+++ b/src/main/java/com/ftpix/sss/controllers/api/ExpenseController.java
@@ -5,7 +5,6 @@ import com.ftpix.sss.models.Expense;
 import com.ftpix.sss.models.ExpenseLimits;
 import com.ftpix.sss.models.User;
 import com.ftpix.sss.services.ExpenseService;
-import com.ftpix.sss.services.HistoryService;
 import com.ftpix.sss.services.UserService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -13,7 +12,6 @@ import io.swagger.annotations.ApiParam;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.web.bind.annotation.*;
 
 import java.sql.SQLException;
@@ -21,7 +19,6 @@ import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/API/Expense")

--- a/src/main/java/com/ftpix/sss/controllers/api/ExpenseController.java
+++ b/src/main/java/com/ftpix/sss/controllers/api/ExpenseController.java
@@ -13,6 +13,7 @@ import io.swagger.annotations.ApiParam;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.web.bind.annotation.*;
 
 import java.sql.SQLException;
@@ -20,6 +21,7 @@ import java.text.ParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/API/Expense")
@@ -143,9 +145,8 @@ public class ExpenseController {
     }
 
     @GetMapping("/diff/{current-day}")
-    public double getDiffWithPreviousPeriod(@PathVariable("current-day") String currentDay) throws SQLException {
+    public double getDiffWithPreviousPeriod(@PathVariable("current-day") String currentDay, @RequestParam(value = "include-recurring", defaultValue = "true") boolean includeRecurring) throws SQLException {
         var currentUser = userService.getCurrentUser();
-        return expenseService.diffWithPreviousPeriod(currentUser, currentDay);
-
+        return expenseService.diffWithPreviousPeriod(currentUser, currentDay, includeRecurring);
     }
 }

--- a/src/main/java/com/ftpix/sss/models/Settings.java
+++ b/src/main/java/com/ftpix/sss/models/Settings.java
@@ -3,7 +3,7 @@ package com.ftpix.sss.models;
 import com.ftpix.sss.services.Encryption;
 
 public class Settings {
-    public static final String CURRENCY_API_KEY = "currencyApiKey", ALLOW_SIGNUP = "allowSignUp", DEMO_MODE = "demoMode", MOTD = "motd", INCLUDE_RECURRING_IN_DIFF = "includeRecurringInDiff";
+    public static final String CURRENCY_API_KEY = "currencyApiKey", ALLOW_SIGNUP = "allowSignUp", DEMO_MODE = "demoMode", MOTD = "motd";
 
     private String name;
 

--- a/src/main/java/com/ftpix/sss/services/ExpenseService.java
+++ b/src/main/java/com/ftpix/sss/services/ExpenseService.java
@@ -3,7 +3,6 @@ package com.ftpix.sss.services;
 import com.ftpix.sss.Constants;
 import com.ftpix.sss.dao.ExpenseDao;
 import com.ftpix.sss.models.*;
-import com.ftpix.sss.utils.DateUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jooq.OrderField;
@@ -157,20 +156,16 @@ public class ExpenseService {
      * ex: we're currently the 10 of july, this should retrieve the amount spent in june from the first to the 10th of june
      *
      * @param user
-     * @param userCurrentDay current date in yyyy-MM-dd format this should be sent by the front end as it might not always be at the same day of the server
+     * @param userCurrentDay   current date in yyyy-MM-dd format this should be sent by the front end as it might not always be at the same day of the server
+     * @param includeRecurring
      * @return
      */
-    public double diffWithPreviousPeriod(User user, String userCurrentDay) throws SQLException {
+    public double diffWithPreviousPeriod(User user, String userCurrentDay, boolean includeRecurring) throws SQLException {
         // find starting point, it should be the beginning of the userCurrentDay month - 1
         var split = userCurrentDay.split("-");
         if (split.length != 3) {
             throw new InvalidParameterException("dates shoud be yyyy-MM-dd format");
         }
-
-
-        boolean includeRecurring = Optional.ofNullable(settingsService.getByName(Settings.INCLUDE_RECURRING_IN_DIFF))
-                .map(settings -> settings.getValue().equalsIgnoreCase("1"))
-                .orElse(true);
 
         int year = Integer.parseInt(split[0]);
         int month = Integer.parseInt(split[1]);

--- a/src/test/java/com/ftpix/sss/controllers/api/ExpenseControllerTest.java
+++ b/src/test/java/com/ftpix/sss/controllers/api/ExpenseControllerTest.java
@@ -1,6 +1,5 @@
 package com.ftpix.sss.controllers.api;
 
-import com.ftpix.sss.Constants;
 import com.ftpix.sss.TestConfig;
 import com.ftpix.sss.TestContainerTest;
 import com.ftpix.sss.dao.CategoryDao;
@@ -14,16 +13,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 import static com.ftpix.sss.Constants.dateFormatter;
 import static org.junit.jupiter.api.Assertions.*;
@@ -51,7 +43,6 @@ public class ExpenseControllerTest extends TestContainerTest {
 
     @Autowired
     private CategoryDao categoryDaoJooq;
-
 
 
     private Expense create(User user, double amount, Category cat, String date, boolean income, int expenseType, long lat, long longitude, String note) throws Exception {
@@ -113,7 +104,8 @@ public class ExpenseControllerTest extends TestContainerTest {
 
         var cats = categoryDaoJooq.getWhere(currentUser);
 
-        Expense newExpense = create(10d, cats.get(0).getId(), dateFormatter.format(today), false, Expense.TYPE_NORMAL, 0, 0, "");
+        Expense newExpense = create(10d, cats.get(0)
+                .getId(), dateFormatter.format(today), false, Expense.TYPE_NORMAL, 0, 0, "");
         Expense newExpense2 = create(10d, cats.get(0).getId(), "2012-03-21", false, Expense.TYPE_NORMAL, 0, 0, "");
 
         String properTime = String.format("%02d", today.getHour()) + ":" + String.format("%02d", today.getMinute());
@@ -202,12 +194,11 @@ public class ExpenseControllerTest extends TestContainerTest {
         create(20d, cats.get(0).getId(), "2024-12-16", false, Expense.TYPE_NORMAL, 0, 0, "");
         create(20d, cats.get(0).getId(), "2024-11-30", false, Expense.TYPE_NORMAL, 0, 0, "");
 
-        var diff = expenseService.diffWithPreviousPeriod(currentUser, "2025-01-15");
+        var diff = expenseService.diffWithPreviousPeriod(currentUser, "2025-01-15", true);
         assertEquals(0.25, diff);
 
         // now we exclude recurring expenses
-        settingsService.save(new Settings(Settings.INCLUDE_RECURRING_IN_DIFF, "0"));
-        diff = expenseService.diffWithPreviousPeriod(currentUser, "2025-01-15");
+        diff = expenseService.diffWithPreviousPeriod(currentUser, "2025-01-15", false);
         assertEquals(0.5, diff);
 
     }


### PR DESCRIPTION
… in a software project. Based on this diff, we can infer the following structure of changes:

---

## 🔧 Summary Overview

This set of diffs appears to be related to:

1. **Updating how recurring expenses are included when calculating differences (e.g., for comparison purposes)**
2. **Refactoring API endpoints and service methods in Java to support dynamic inclusion/exclusion of recurring items**
3. **Modifying Flutter/Dart UI code that uses shared preferences to store user settings, and passes those into backend calls**
4. **Removing obsolete references / unused imports**

---

## 📂 Breakdown by Module

### ✅ 1. Backend (`Java`)
#### `/src/main/java/com/ftpix/sss/controllers/api/ExpenseController.java`
- Added `@DefaultValue` import from Spring Boot.
- Modified API endpoint for `/diff/{current-day}`:
  - Accepts optional query parameter: `include-recurring=true|false`
  - Passes this flag to the service method.

#### `/src/main/java/com/ftpix/sss/services/ExpenseService.java`
- Removed unused import: `com.ftpix.sss.utils.DateUtils`.
- Modified method signature of `diffWithPreviousPeriod(...)`:
  - Added boolean parameter `includeRecurring`.
  - No longer reads setting from `settingsService`. Instead, relies entirely on input argument.

#### `/src/main/java/com/ftpix/sss/models/Settings.java`
- Removed constant: `INCLUDE_RECURRING_IN_DIFF` (no longer used by backend).

#### `/src/main/java/com/ftpix/sss/controllers/api/ExpenseController.java`
- Updated test case in `diffWithPreviousPeriod`:
  - The method now takes a third parameter (`includeRecurring`) explicitly.
  - Removed reliance on setting-based configuration.

---

### ✅ 2. Frontend (Flutter/Dart)
#### `/src/main/app/lib/expenses/state/expense_list.dart`
- Imported dependencies:
  - `shared_preferences` to load settings
  - Custom settings screen import (`package:spend_spent_spent/settings/views/screens/settings.dart`)
- Changed logic in comparison method:
  - Reads user preference for including recurring expenses via `SharedPreferences`.
  - Passes this setting into the API call as `includeRecurring`.

---

### ✅ 3. Shared Behavior (Flutter + Backend)
This is a change where behavior related to **including/excluding recurring expenses** during period comparisons was moved out of backend settings and made dynamic through UI/user preferences.

> 🧠 This makes sense for personalization — users may want to toggle this mode themselves rather than relying on an admin-controlled feature flag.

---

### ✅ 4. Tests (JUnit)
#### `/src/main/java/com/ftpix/sss/controllers/api/ExpenseController.java`
- Updated existing test cases around `diffWithPreviousPeriod`:
  - Now explicitly pass `true` or `false` depending on whether recurring expenses should be included.
  - Removed previous code that depended on global setting (`settingsService.save(...)`).

---

## 🛠️ Technical Notes

| Area | Change Description |
|------|--------------------|
| **Backend** | Refactored to make inclusion of recurring expenses configurable at runtime rather than via static settings. Improved modularity and UX support. | | **Frontend (Dart)** | Introduced shared preferences integration so UI can read & apply user preference about whether to include recurring expenses in visual comparisons. | | **Tests** | Updated tests accordingly to reflect the change from global settings to method parameters. |

---

## 💡 Suggested Improvements

1. ✅ Add unit tests on the backend to ensure that `includeRecurring` behaves correctly with edge cases (e.g., invalid dates, nulls).
2. 🔄 Consider caching or defaulting the setting value in Dart if not available (`SharedPreferences` might return null).
3. 🔁 If multiple screens use this logic (not just comparison), extract shared function to avoid duplication.

---

## 🧹 Clean-up / Housekeeping

- Removed unused import: `DateUtils`
- Removed constant `INCLUDE_RECURRING_IN_DIFF` from Settings model
- Updated integration tests accordingly
- No breaking changes — backward compatibility maintained for new behavior via defaults (`default = true`)

---

## 📝 Conclusion

These diffs represent a **refinement in logic flow** where:
> Instead of using a central setting (admin-controlled), the frontend allows end-users to decide whether recurring expenses should be included in comparison calculations, improving usability and flexibility.

This is a positive evolution for user preferences being honored at runtime and aligning with modern app design trends: personalization + granular control.